### PR TITLE
Make sure Hugging Face download stats work, better discoverability

### DIFF
--- a/guided_diffusion/models.py
+++ b/guided_diffusion/models.py
@@ -2,6 +2,8 @@ import math
 import torch
 import torch.nn as nn
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 def get_timestep_embedding(timesteps, embedding_dim):
     """
@@ -189,7 +191,7 @@ class AttnBlock(nn.Module):
         return x+h_
 
 
-class Model(nn.Module):
+class Model(nn.Module, PyTorchModelHubMixin):
     def __init__(self, config):
         super().__init__()
         self.config = config

--- a/push_to_hf.py
+++ b/push_to_hf.py
@@ -1,0 +1,32 @@
+from guided_diffusion.models import Model
+import torch
+import yaml
+from utils import dict2namespace
+
+
+def load_pretrained_diffusion_model(config):
+    model = Model(config)
+    ckpt = "checkpoints/celeba_hq.ckpt"
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    config.device = device
+    model.load_state_dict(torch.load(ckpt, map_location=device))
+    model.to(device)
+    model.eval()
+    for param in model.parameters():
+        param.requires_grad = False
+    model = torch.nn.DataParallel(model)    
+    return model, device
+
+
+with open( "data/celeba_hq.yml", "r") as f:
+    config1 = yaml.safe_load(f)
+
+config = dict2namespace(config1)
+
+model, device = load_pretrained_diffusion_model(config)
+
+# push to hub
+model.push_to_hub("nielsr/bird-demo")
+
+# reload
+model = Model.from_pretrained("nielsr/bird-demo")


### PR DESCRIPTION
Dear @hamadichihaoui and team,

Thanks for this nice work!

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the BIRD model using `from_pretrained` (and push it using `push_to_hub`), track download numbers (similar to models in the Transformers library), and have a nice model card. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from guided_diffusion.models import Model

model = Model.from_pretrained("nielsr/bird-demo")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads it automatically from the hub. The `safetensors` format is used to ensure safe serialization of the weights rather than pickle.

Also, tags can be added to the model card to improve discoverability, such as "image-denoising" etc.

Would you be interested in this integration?

Kind regards,

Niels
ML Engineer @ HF 🤗 